### PR TITLE
Add example that explains how to manage terraform providers programmatically

### DIFF
--- a/02-manage-providers-programmatically/aws/config.tm.hcl
+++ b/02-manage-providers-programmatically/aws/config.tm.hcl
@@ -1,0 +1,20 @@
+// Configure the main AWS Provider and an additional alias Provider to demonstrate multi-region setup
+globals "terraform" "providers" "aws" {
+  enabled = true
+  source  = "hashicorp/aws"
+  version = "~> 5.0"
+  config = {
+    region = "us-east-1"
+  }
+}
+
+globals "terraform" "providers" "aws.west-1" {
+  config = {
+    region = "us-west-1"
+  }
+}
+
+globals "terraform" "providers" "random" {
+  version = "~> 4.0"
+}
+

--- a/02-manage-providers-programmatically/aws/us-east-1/vpc/main/_terramate_generated_providers.tf
+++ b/02-manage-providers-programmatically/aws/us-east-1/vpc/main/_terramate_generated_providers.tf
@@ -1,0 +1,24 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "1.6.0"
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 4.0"
+    }
+  }
+}
+provider "aws" {
+  region = "us-east-1"
+}
+provider "aws" {
+  region = "us-west-1"
+  alias  = "west-1"
+}

--- a/02-manage-providers-programmatically/aws/us-east-1/vpc/main/main.tf
+++ b/02-manage-providers-programmatically/aws/us-east-1/vpc/main/main.tf
@@ -1,0 +1,3 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}

--- a/02-manage-providers-programmatically/aws/us-east-1/vpc/main/stack.tm.hcl
+++ b/02-manage-providers-programmatically/aws/us-east-1/vpc/main/stack.tm.hcl
@@ -1,0 +1,5 @@
+stack {
+  name        = "Main VPC"
+  description = "This stack deploys a simple AWS VPC in us-east-1."
+  id          = "05cb70d5-a2a6-4b36-bf20-2e01ade1070e"
+}

--- a/02-manage-providers-programmatically/aws/us-west-1/vpc/main/_terramate_generated_providers.tf
+++ b/02-manage-providers-programmatically/aws/us-west-1/vpc/main/_terramate_generated_providers.tf
@@ -1,0 +1,24 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "1.6.0"
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 4.0"
+    }
+  }
+}
+provider "aws" {
+  region = "us-east-1"
+}
+provider "aws" {
+  region = "us-west-1"
+  alias  = "west-1"
+}

--- a/02-manage-providers-programmatically/aws/us-west-1/vpc/main/main.tf
+++ b/02-manage-providers-programmatically/aws/us-west-1/vpc/main/main.tf
@@ -1,0 +1,5 @@
+resource "aws_vpc" "main" {
+  provider = aws.west-1
+
+  cidr_block = "10.0.0.0/16"
+}

--- a/02-manage-providers-programmatically/aws/us-west-1/vpc/main/stack.tm.hcl
+++ b/02-manage-providers-programmatically/aws/us-west-1/vpc/main/stack.tm.hcl
@@ -1,0 +1,5 @@
+stack {
+  name        = "Main VPC"
+  description = "This stack deploys a simple AWS VPC in us-west-1."
+  id          = "2e03e2fb-ce5f-4c19-9757-e4636491a446"
+}

--- a/02-manage-providers-programmatically/config.tm.hcl
+++ b/02-manage-providers-programmatically/config.tm.hcl
@@ -1,0 +1,11 @@
+// Configure default Terraform version and default providers
+globals "terraform" {
+  version = "1.6.0"
+}
+
+# Will be added to all stacks
+globals "terraform" "providers" "random" {
+  source  = "hashicorp/random"
+  version = "~> 3.5"
+  enabled = true
+}

--- a/02-manage-providers-programmatically/gcp/config.tm.hcl
+++ b/02-manage-providers-programmatically/gcp/config.tm.hcl
@@ -1,0 +1,9 @@
+globals "terraform" "providers" "gcp" {
+  enabled = true
+  source  = "hashicorp/google"
+  version = "~> 5.6"
+  config = {
+    project     = "my-project-id"
+    region      = "europe-west1"
+  }
+}

--- a/02-manage-providers-programmatically/gcp/europe-west1/vpc/main-vpc/_terramate_generated_providers.tf
+++ b/02-manage-providers-programmatically/gcp/europe-west1/vpc/main-vpc/_terramate_generated_providers.tf
@@ -1,0 +1,21 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "1.6.0"
+}
+terraform {
+  required_providers {
+    gcp = {
+      source  = "hashicorp/google"
+      version = "~> 5.6"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+provider "gcp" {
+  project = "my-project-id"
+  region  = "europe-west1"
+}

--- a/02-manage-providers-programmatically/gcp/europe-west1/vpc/main-vpc/main.tf
+++ b/02-manage-providers-programmatically/gcp/europe-west1/vpc/main-vpc/main.tf
@@ -1,0 +1,3 @@
+resource "google_compute_network" "vpc" {
+  name = terramate.stack.name
+}

--- a/02-manage-providers-programmatically/gcp/europe-west1/vpc/main-vpc/stack.tm.hcl
+++ b/02-manage-providers-programmatically/gcp/europe-west1/vpc/main-vpc/stack.tm.hcl
@@ -1,0 +1,5 @@
+stack {
+  name        = "Main VPC"
+  description = "This stack deploys a simple Google Cloud VPC in europe-west1."
+  id          = "b1fcee91-6aeb-402a-b9d9-a9e7b6cc82ae"
+}

--- a/02-manage-providers-programmatically/imports.tm.hcl
+++ b/02-manage-providers-programmatically/imports.tm.hcl
@@ -1,0 +1,3 @@
+import {
+  source = "./imports/generate_providers.tm.hcl"
+}

--- a/02-manage-providers-programmatically/imports/generate_providers.tm.hcl
+++ b/02-manage-providers-programmatically/imports/generate_providers.tm.hcl
@@ -1,0 +1,62 @@
+generate_hcl "_terramate_generated_providers.tf" {
+
+  lets {
+    required_providers = { for k, v in tm_try(global.terraform.providers, {}) :
+      k => {
+        source  = v.source
+        version = v.version
+        } if tm_alltrue([
+          tm_try(v.enabled, true),
+          tm_length(tm_split(".", k)) == 1,
+      ])
+    }
+
+    providers = { for k, v in tm_try(global.terraform.providers, {}) :
+      k => v.config if tm_alltrue([
+        tm_length(tm_split(".", k)) == 1,
+        tm_try(v.enabled, true),
+        tm_can(v.config)
+      ])
+    }
+
+    providers_aliases = { for k, v in tm_try(global.terraform.providers, {}) :
+      k => v.config if tm_alltrue([
+        tm_length(tm_split(".", k)) == 2,
+        tm_try(v.enabled, true),
+        tm_can(v.config)
+      ])
+    }
+  }
+
+  content {
+    # terraform version constraints
+    terraform {
+      required_version = tm_try(global.terraform.version, "~> 1.5")
+    }
+
+    # Provider version constraints
+    terraform {
+      tm_dynamic "required_providers" {
+        attributes = let.required_providers
+      }
+    }
+
+    # Provider configs
+    tm_dynamic "provider" {
+      for_each   = let.providers
+      labels     = [provider.key]
+      attributes = provider.value
+    }
+
+    # Provider aliases
+    tm_dynamic "provider" {
+      for_each   = let.providers_aliases
+      labels     = [tm_split(".", provider.key)[0]]
+      attributes = provider.value
+
+      content {
+        alias = tm_split(".", provider.key)[1]
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ straightforward to understand and quick to adopt.
 
 This example shows how to keep your Terraform DRY using the Terramate Code Generation to generate Terraform files such
 as Provider and Backend configurations.
+
+⚡ **[**`Manage Terraform Providers programmatically with Terramate Globals and Code Generation`**](./02-manage-providers-programmatically/)**
+
+This example demonstrates how to manage Terraform Providers programmatically with Terramate Globals and Code Generation.


### PR DESCRIPTION
This example explains how to manage Terraform providers programmatically using Terramate Globals. This will be published as an example used in a new guide which we will publish in December.